### PR TITLE
Update aiobotocore to version 1.4.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "aiobotocore" %}
-{% set version = "1.3.3" %}
+{% set version = "1.4.1" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: b6bae95c55ef822d790bf8ebf6aed3d09b33e2817fa5f10e16a77028332963c2
+  sha256: 09f06723d1d69c6d407d9a356ca65ab42a5b7b73a45be4b1ed0ed1a6b6057a9f
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,10 @@ requirements:
 test:
   imports:
     - aiobotocore
+  commands:
+    - pip check
+  requires:
+    - pip
 
 about:
   home: https://github.com/aio-libs/aiobotocore


### PR DESCRIPTION
1. check the upstream
https://github.com/aio-libs/aiobotocore

2. check the pinnings
https://github.com/aio-libs/aiobotocore/blob/master/setup.py

3. check changelogs
https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst

There was one breaking change introduced in previous versions that has been resolved in version 1.4.1
1.4.1 (2021-08-24)
put backwards incompatible changes behind AIOBOTOCORE_DEPRECATED_1_4_0_APIS env var. This means that #876 will not work unless this env var has been set to 0.

The issue has been resolved
https://github.com/aio-libs/aiobotocore/issues/876

the rest of the changes are bug fixes or changes made to match botocore_

1.4.0 (2021-08-20)
fix retries via config #877
remove AioSession and get_session top level names to match botocore_
change exceptions raised to match those of botocore_, see mappings

4. additional research
There were no open issues mentioned in conda-forge
https://github.com/conda-forge/aiobotocore-feedstock/issues

5. verify dev_url
6. verify doc_url
7. added pip to the test section
9. verify the test section
10. additional tests

    To run the initial test the `aiobotocore` packages was tested using the following command:
    `conda build aiobotocore-feedstock --test`
    The final result was as follows:
    `All tests passed`

    Once the package was build additional tests were made. 
    In order to test `aiobotocore` the `s3fs` package was modified to work with version 1.4.1
    then the following command was used for testing:
    `conda build s3fs-feedstock --test`
    the final result was the following:
    `All tests passed`

based on the research conducted, and on the tests results we can conclude that it is safe to update `aiobotocore` to version 1.4.1
