### PR TITLE
aiobotocore 2.1.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,11 +30,11 @@ requirements:
 test:
   imports:
     - aiobotocore
-  commands:
-    - pip check
-    - python <3.10
   requires:
     - pip
+    - python <3.10
+  commands:
+    - pip check
 
 about:
   home: https://github.com/aio-libs/aiobotocore

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "aiobotocore" %}
-{% set version = "1.4.1" %}
+{% set version = "2.1.0" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 09f06723d1d69c6d407d9a356ca65ab42a5b7b73a45be4b1ed0ed1a6b6057a9f
+  sha256: 5fd4d7aefa0896fe4dd32815ead8a52ed5ccb8016c7c5743fe8ff71c3c074120
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
   host:
     - python
     - pip
-
+    - setuptools
   run:
     - aiohttp >=3.3.1
     - aioitertools >=0.5.1
@@ -32,6 +32,7 @@ test:
     - aiobotocore
   commands:
     - pip check
+    - python <3.10
   requires:
     - pip
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,13 +17,13 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
 
   run:
     - aiohttp >=3.3.1
     - aioitertools >=0.5.1
-    - botocore >=1.20.106,<1.20.107
+    - botocore >=1.23.24,<1.23.25
     - python >=3.6
     - wrapt >=1.10.10
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - python
     - pip
     - setuptools
+    - wheel
   run:
     - aiohttp >=3.3.1
     - aioitertools >=0.5.1


### PR DESCRIPTION
Update aiobotocore to 2.1.0

Changelog: https://github.com/aio-libs/aiobotocore/blob/2.1.0/CHANGES.rst
License: https://github.com/aio-libs/aiobotocore/blob/2.1.0/LICENSE
Upstream setup file: https://github.com/aio-libs/aiobotocore/blob/2.1.0/setup.py

Actions:
1. Add setuptools in host
2. Update dependencies in run: botocore >=1.23.24,<1.23.25
3. Fix python in host and test/requires