### PR TITLE
aiobotocore 2.12.3

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/botocore-feedstock/pr58/dab749f

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/botocore-feedstock/pr58/dab749f

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "aiobotocore" %}
-{% set version = "2.7.0" %}
+{% set version = "2.12.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 506591374cc0aee1bdf0ebe290560424a24af176dfe2ea7057fe1df97c4f0467
+  sha256: e2a2929207bc5d62eb556106c2224c1fd106d5c65be2eb69f15cc8c34c44c236
 
 build:
   skip: true  #[py<38]
@@ -23,11 +23,11 @@ requirements:
   run:
     - aiohttp >=3.7.4.post0,<4.0.0
     - aioitertools >=0.5.1,<1.0.0
-    - botocore >=1.31.16,<1.31.65
+    - botocore >=1.34.41,<1.34.70
     - python
     - wrapt >=1.10.10,<2.0.0
   run_constrained:
-    - boto3 >=1.28.16,<1.28.65
+    - boto3 >=1.34.41,<1.34.70
 
 test:
   imports:
@@ -50,7 +50,6 @@ about:
     services also work.
   dev_url: https://github.com/aio-libs/aiobotocore
   doc_url: https://aiobotocore.readthedocs.io
-  
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
**Destination channel:**

### Links

- [PKG-4617](https://anaconda.atlassian.net/browse/PKG-4617)
- release-notes-tagged: https://github.com/aio-libs/aiobotocore/releases/tag/2.12.3
- release-diff: https://github.com/aio-libs/aiobotocore/compare/2.7.0...2.12.3
- changelog: https://github.com/aio-libs/aiobotocore/blob/master/CHANGES.rst
- license: https://github.com/aio-libs/aiobotocore/blob/master/LICENSE
- requirements-tagged:
  - https://github.com/aio-libs/aiobotocore/blob/2.12.3/setup.cfg
  - https://github.com/aio-libs/aiobotocore/blob/2.12.3/setup.py


### Explanation of changes:

- Update pinnings

### Notes:

- The build order of aiobotocore 2.12.3 and downstream packages: 
  - botocore 1.34.69:
    -> boto3 1.34.69
    -> aiobotocore 2.12.3 ->  s3fs 2024.3.1
    -> s3transfer 0.10.1


[PKG-4617]: https://anaconda.atlassian.net/browse/PKG-4617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ